### PR TITLE
Remove umd from siwf build

### DIFF
--- a/packages/siwf/package.json
+++ b/packages/siwf/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],
-  "main": "./dist/index.umd.cjs",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/siwf/scripts/package.cjs
+++ b/packages/siwf/scripts/package.cjs
@@ -26,13 +26,13 @@ delete rootPackage['files'];
 delete rootPackage['devDependencies'];
 
 // Setup the main and types correctly
-rootPackage['main'] = 'index.umd.cjs';
+rootPackage['main'] = 'index.cjs';
 rootPackage['module'] = 'index.js';
 rootPackage['types'] = 'index.d.ts';
 (rootPackage['exports'] = {
   '.': {
     types: './index.d.ts',
-    require: './index.umd.cjs',
+    require: './index.cjs',
     import: './index.js',
     default: './index.js',
   },

--- a/packages/siwf/vite.config.ts
+++ b/packages/siwf/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       name: 'siwf',
       // the proper extensions will be added
       fileName: 'index',
-      formats: ['es', 'umd', 'cjs'],
+      formats: ['es', 'cjs'],
     },
   },
   test: {


### PR DESCRIPTION
UMD was having issues building, so disabling for now.

CJS should be enough for all nodejs projects, es for all frontend and es projects.

with @mattheworris 